### PR TITLE
compose: Fix ports handling

### DIFF
--- a/docker-compose-koillectionPG.yml
+++ b/docker-compose-koillectionPG.yml
@@ -32,6 +32,8 @@ services:
         container_name: mysql
         image: mysql:latest
         restart: always
+        ports:
+            - 33060:3306
         environment:
             - MYSQL_DATABASE=koillection
             - MYSQL_ROOT_PASSWORD=password


### PR DESCRIPTION
mysql works on 3306, but that was only reachable from inside docker network. Now it's reachable under 33060 from the outside network as well.

Possbily to be closed:
- safety concerns for exposing mysql to net
- mysql docker container name alias works on localhost.