### PR TITLE
Make whole dropdown menu items clickable

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1456,6 +1456,10 @@ html.loading:before {
     border-bottom: 1px solid #e0e0e0;
     line-height: 1.5rem;
     margin: 0;
+}
+
+.dropdown-menu a {
+    display: block;
     padding: 15px 35px 10px 20px;
 }
 


### PR DESCRIPTION
Unitl now, we could only click on a link in dropdown menu item block directly (on the blue area):
![Screenshot from 2023-11-13 17-13-03](https://github.com/museum-engineering-project/koillectionPG/assets/86925036/7284b31c-6c13-4ad4-a3e4-affc53e01aff)

I made some small changes in styles to make it possible to click on the whole block area (the whole menu item is treated as a link now):
![Screenshot from 2023-11-13 17-14-07](https://github.com/museum-engineering-project/koillectionPG/assets/86925036/c6c01b6d-71eb-4d84-9f4e-392f643adab0)

