### PR TITLE
Changing language by unlogged user

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -2303,3 +2303,12 @@ tr {
 .bottom-margin {
     margin-bottom: 30px !important;
 }
+
+.locale-dropdown-sidebar {
+    display: block;
+    font-size: 16px;
+    line-height: 35px;
+    outline: none;
+    padding: 7px 15px;
+    padding-left: 22px;
+}

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -2309,6 +2309,12 @@ tr {
     font-size: 16px;
     line-height: 35px;
     outline: none;
+}
+
+.locale-dropdown-sidebar-span {
+    cursor: pointer; 
+    display: block; 
+    color: white;
     padding: 7px 15px;
     padding-left: 22px;
 }

--- a/assets/styles/themes/dark.css
+++ b/assets/styles/themes/dark.css
@@ -39,7 +39,8 @@
 .select2-container--default .select2-results__option--highlighted[aria-selected],
 .select2-container--default .select2-results__option[aria-selected="true"],
 .sidebar-wrapper .header-logo:hover, .header-profile .down-background, .btn, .btn:focus, .btn:hover,
-.modal-custom .modal-header, .box h1, .box .logo, .dropdown-menu li:hover {
+.modal-custom .modal-header, .box h1, .box .logo, .dropdown-menu li:hover,
+.locale-dropdown-sidebar:hover {
     background-color: var(--primary-color);
 }
 
@@ -74,7 +75,7 @@ body, .main, .header-logo, .nav-wrapper #search_term, .sidebar-element.separate-
 }
 
 /** FONT COLOR MEDIUM **/
-i, body, .sidebar-element span, .header-logo a, .toast {
+i, body, .sidebar-element span, .header-logo a, .toast, .locale-dropdown-sidebar:hover {
     color: var(--font-color-medium);
 }
 

--- a/assets/styles/themes/light.css
+++ b/assets/styles/themes/light.css
@@ -54,7 +54,7 @@ a, .breadcrumb-item.active a, .dropdown-menu i, .navigation-block i, .autocomple
 }
 
 /** PRIMARY COLOR DARK **/
-.sidebar-element a:hover, .sidebar-element.current a {
+.sidebar-element a:hover, .sidebar-element.current a, .locale-dropdown-sidebar:hover {
     background-color: var(--primary-color-dark);
 }
 
@@ -98,7 +98,7 @@ footer, .image-label, .datum-row span.country-name, .breadcrumb-item a {
 }
 
 /** FONT COLOR LIGHTEST **/
-i, .sidebar-element span, .header-logo a, .toast, .box h1 {
+i, .sidebar-element span, .header-logo a, .toast, .box h1, .locale-dropdown-sidebar-span {
     color: var(--font-color-lightest);
 }
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -29,9 +29,9 @@ final readonly class LocaleListener
     {
         $request = $event->getRequest();
 
-        if (!$request->hasPreviousSession()) {
-            return;
-        }
+        // if (!$request->hasPreviousSession()) {
+        //     return;
+        // }
 
         $locale = $request->query->get('_locale');
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -28,11 +28,6 @@ final readonly class LocaleListener
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
-
-        // if (!$request->hasPreviousSession()) {
-        //     return;
-        // }
-
         $locale = $request->query->get('_locale');
 
         if ($locale && \in_array($locale, $this->enabledLocales)) {

--- a/templates/App/_partials/_nav/_shared.html.twig
+++ b/templates/App/_partials/_nav/_shared.html.twig
@@ -14,6 +14,24 @@
     </form>
 </li>
 
+<li>
+    <div class="locale-dropdown-sidebar" data-controller="dropdown">
+        <span data-action="click->dropdown#show" style="cursor: pointer">
+            <i class="fa fa-language fa-fw"></i>
+        </span>
+
+        <ul class="dropdown-menu hidden" data-dropdown-target="menu">
+            {% for key, locale in getLocales() %}
+                <li>
+                    <a href="{{ path(app.request.get('_route'), app.request.get('_route_params')) }}?_locale={{ key }}">
+                        <span class="flag">{{ getCountryFlag(key) }}</span><span>{{ locale|trans }}</span>
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+</li>
+
 <li class="{{ 'app_shared_collection' in route or 'app_shared_item' in route ? 'current' }} sidebar-element">
     <a
             href="{{ path('app_shared_collection_index') }}">

--- a/templates/App/_partials/_nav/_shared.html.twig
+++ b/templates/App/_partials/_nav/_shared.html.twig
@@ -14,10 +14,12 @@
     </form>
 </li>
 
-<li>
-    <div class="locale-dropdown-sidebar" data-controller="dropdown">
-        <span data-action="click->dropdown#show" style="cursor: pointer">
+<li class="locale-dropdown-sidebar" data-controller="dropdown">
+        <span class="locale-dropdown-sidebar-span" data-action="click->dropdown#show">
             <i class="fa fa-language fa-fw"></i>
+            <span class="current-locale" style="margin-left: 20px;">
+            {{ getLocaleLabel(app.request.locale)|trans }}
+            </span>
         </span>
 
         <ul class="dropdown-menu hidden" data-dropdown-target="menu">
@@ -29,7 +31,10 @@
                 </li>
             {% endfor %}
         </ul>
-    </div>
+</li>
+
+<li class="separate-item sidebar-element">
+    <div></div>
 </li>
 
 <li class="{{ 'app_shared_collection' in route or 'app_shared_item' in route ? 'current' }} sidebar-element">


### PR DESCRIPTION
Now unlogged user can change language using the following button in the sidebar:
![image](https://github.com/museum-engineering-project/koillectionPG/assets/86925036/f7a60977-a504-4095-8648-971bdee2e910)
This button works the same as the one on the login page. 
I haven't added this option for admin user and any other logged user as they can change language in profile settings, so possibility to change language in two places can be a bit confusing, especially that they work differently (this setting is stored in session, so it is temporary, while language set in user profile is permanent - it will be kept until the user changes it).