### PR TITLE
compose: Fix site not available on dev

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -64,6 +64,7 @@ http {
         add_header Service-Worker-Allowed "/";
 
         root /var/www/koillection/public;
+        listen 80;
         listen 443;
         server_name localhost;
         client_max_body_size 100M;


### PR DESCRIPTION
Webserver didn't listen on port 80, which resulted in lack of connection