### PR TITLE
traefik: Extend functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ docker-compose.yml
 !/public/uploads/.gitkeep
 /public/tmp/*
 !public/tmp/.gitkeep
-/letsencrypt/
+/letsencrypt
+/certs
+
 
 /.idea/*
 ###> lexik/jwt-authentication-bundle ###

--- a/docker-compose-koillectionPG_prod.yml
+++ b/docker-compose-koillectionPG_prod.yml
@@ -23,8 +23,7 @@ services:
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.koillection.entrypoints=websecure"
-            # Replace YOUR_IP_OR_DOMAIN with your domain or IP
-            - "traefik.http.routers.koillection.rule=Host(`YOUR_IP_OR_DOMAIN`)"
+            - "traefik.http.routers.koillection.rule=Host(`127.0.0.1`)" # || Host(`YOUR_IP_OR_DOMAIN`) "
             - "traefik.http.routers.koillection.tls=true"
         depends_on:
             - mysql

--- a/docker-compose-koillectionPG_prod.yml
+++ b/docker-compose-koillectionPG_prod.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     koillection:
         # TODO: Once koillectionPG is published to Dockerhub, replace with koillectionPG/koillectionPG:latest
-        #image: koillection/koillection:latest
+        # image: koillection/koillection:latest
         build:
           dockerfile: Dockerfile
         container_name: koillection
@@ -54,17 +54,28 @@ services:
         - "--entrypoints.websecure.address=:443"
         - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
         - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
-        # Uncomment if you want let's encrypt cert and have 80 port unblocked for ACME HTTP challenge.
+        # if lets_encrypt_cert
+        # Note: Requires port 80 unblocked for HTTP ACME Challenge
         #- "--certificatesresolvers.myresolver.acme.httpchallenge=true"
         #- "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
         #- "--certificatesresolvers.myresolver.acme.tlschallenge=true"
         #- "--certificatesresolvers.myresolver.acme.email=user@domain.com" # Replace with your email
         #- "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+        # endif lets_encrypt_cert
+        # if own_cert
+        # - --providers.file.directory=/etc/traefik/dynamic
+        # endif own_cert
       ports:
         - "80:80"
         - "443:443"
       volumes:
         - "/var/run/docker.sock:/var/run/docker.sock:ro"
-        - "./letsencrypt:/letsencrypt"
+        # if lets_encrypt_cert
+        # - "./letsencrypt:/letsencrypt"
+        # endif lets_encrypt_cert
+        # if own_cert
+        # - "./certs:/etc/certs"
+        # - "./docker/traefik-certs.yml:/etc/traefik/dynamic/traefik-certs.yml"
+        # endif own_cert
       labels:
         - "traefik.enable=true"

--- a/docker/traefik-certs.yml
+++ b/docker/traefik-certs.yml
@@ -1,0 +1,9 @@
+tls:
+  stores:
+    default:
+      defaultCertificate:
+          certFile: /etc/certs/examplecert.crt
+          keyFile: /etc/certs/examplecert.key
+  certificates:
+    - certFile: /etc/certs/examplecert.crt
+      keyFile: /etc/certs/examplecert.key


### PR DESCRIPTION
# How to test the change?
## Use own certificate
![obraz](https://github.com/museum-engineering-project/koillectionPG/assets/77413489/8d6d06f6-905c-4afe-9bc4-b500b54104b9)
```bash
mkdir certs && cd certs
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 # generate new key and cert
openssl rsa -in examplecert.key -out ex.key --passin pass:1234# remove password 1234
mv ex.key examplecert.key
mv cert.pem examplecert.cert
```
**Note**: Don't forget to replace `YOUR_IP_OR_DOMAIN` and uncomment proper sections in code.