### PR TITLE
item/dublincore: Fix shared button not working

### DIFF
--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -212,6 +212,7 @@ class ItemController extends AbstractController
     }
 
     #[Route(path: '/items/{id}/generate-dublincore-xml', name: 'app_item_generate_dublin_core_xml', methods: ['GET', 'POST'])]
+    #[Route(path: '/user/{username}/items/{id}/generate-dublincore-xml', name: 'app_shared_item_generate_dublin_core_xml', methods: ['GET', 'POST'])]
     public function generateDublinCoreXML(Request $request, Item $item, DublinCoreXMLGenerator $dcGenerator): Response
     {
         $generatedXML = $dcGenerator->generateDublinCoreXML($item, $request->getSchemeAndHttpHost());

--- a/templates/App/Item/_content.html.twig
+++ b/templates/App/Item/_content.html.twig
@@ -47,7 +47,7 @@
             </div>
         {% elseif context == 'shared' %}
             <div class="btn-holder">
-                    <a href="{{ path('app_item_generate_dublin_core_xml', {'id': item.id}) }}" class="button"
+                    <a href="{{ path('app_shared_item_generate_dublin_core_xml', {'id': item.id}) }}" class="button"
                         title="{{ 'tooltip.generate_dublin_core_xml'|trans }}">
                         <i class="fa fa fa-file-code-o fa-fw"></i>
                     </a>


### PR DESCRIPTION
For not logged user path for logged user was used, which resulted in redirection to login page.