### PR TITLE
mlang: Remove no spaces support

### DIFF
--- a/assets/controllers/select/default_controller.js
+++ b/assets/controllers/select/default_controller.js
@@ -79,7 +79,7 @@ function transMlang(text) {
         return "";
     }
 
-    var openingTag = "{[ \t]*mlang[ \t]*" + Translator.locale + "[ \t]*(default)?[ \t]*}";
+    var openingTag = "{[ \t]*mlang[ \t]+" + Translator.locale + "([ \t]+default)?[ \t]*}";
     var closingTag = "{[ \t]*mlang[ \t]*}";
 
     var pattern = new RegExp(openingTag + ".*?" + closingTag, 'g');
@@ -87,7 +87,7 @@ function transMlang(text) {
 
     // if no tags were matched, try to match tags with default attribute
     if (matches.length === 0) {
-        openingTag = "{[ \t]*mlang[ \t]*.*?[ \t]*default[ \t]*}";
+        openingTag = "{[ \t]*mlang([ \t]+.*)?[ \t]+default[ \t]*}";
         pattern = new RegExp(openingTag + ".*?" + closingTag, 'g');
         matches = [...text.matchAll(pattern)];
     }
@@ -103,7 +103,7 @@ function transMlang(text) {
     }
 
     // remove all remaining (unmatched) mlang tags and their content
-    text = text.replace(new RegExp("{[ \t]*mlang[ \t]*.*?[ \t]*}" + ".*?" + closingTag, 'g'), "");
+    text = text.replace(new RegExp("{[ \t]*mlang([ \t]+.*)?[ \t]*}" + ".*?" + closingTag, 'g'), "");
 
     return text;
 }

--- a/src/Twig/AppRuntime.php
+++ b/src/Twig/AppRuntime.php
@@ -52,7 +52,7 @@ readonly class AppRuntime implements RuntimeExtensionInterface
             $locale = $this->translator->getLocale();
         }
         
-        $openingTag = "{[ \t]*mlang[ \t]*" . $locale . "[ \t]*(default)?[ \t]*}";
+        $openingTag = "{[ \t]*mlang[ \t]+" . $locale . "([ \t]+default)?[ \t]*}";
         $closingTag = "{[ \t]*mlang[ \t]*}";
 
         $pattern = "/" . $openingTag . ".*?" . $closingTag . "/";
@@ -61,7 +61,7 @@ readonly class AppRuntime implements RuntimeExtensionInterface
 
         // if no tags were matched, try to match tags with default attribute
         if (count($matches[0]) === 0) {
-            $openingTag = "{[ \t]*mlang[ \t]*.*?[ \t]*default[ \t]*}";
+            $openingTag = "{[ \t]*mlang([ \t]+.*)?[ \t]+default[ \t]*}";
             $pattern = "/" . $openingTag . ".*?" . $closingTag . "/";
             $matches = [];
             preg_match_all($pattern, $text, $matches);
@@ -78,7 +78,7 @@ readonly class AppRuntime implements RuntimeExtensionInterface
         }
 
         // remove all remaining (unmatched) mlang tags and their content
-        $text = preg_replace("/{[ \t]*mlang[ \t]*.*?[ \t]*}" . ".*?" . $closingTag . "/", "", $text);
+        $text = preg_replace("/{[ \t]*mlang([ \t]+.*)?[ \t]*}" . ".*?" . $closingTag . "/", "", $text);
 
         return $text;
     }


### PR DESCRIPTION
E.g.{mlangendefault} was accepted, even though
it shouldn't have been.